### PR TITLE
Fix incorrect position of cursor

### DIFF
--- a/zca-widget
+++ b/zca-widget
@@ -2,3 +2,4 @@ autoload zca-usetty-wrapper zca
 
 zca-usetty-wrapper zca "$@"
 
+zle reset-prompt


### PR DESCRIPTION
When press `<C-T>` (default hotkey of zsh-cmd-architect), then press `q` to quit, the cursor will occur in wrong position

![image](https://user-images.githubusercontent.com/32936898/141122344-8ec8365e-494b-4261-8ca6-c24da27aee26.png)

After this PR, the cursor will recover to correct position.

![image](https://user-images.githubusercontent.com/32936898/141122533-98a344c2-b9c4-458a-a015-8380ad2ea934.png)